### PR TITLE
Handles BUILDKITE_PLUGINS being empty (e.g. no plugins requested)

### DIFF
--- a/check-plugins
+++ b/check-plugins
@@ -33,6 +33,11 @@ if [[ ! -e "$WHITELIST_FILE_PATH" ]]; then
   exit 1
 fi
 
+if [[ -z "${BUILDKITE_PLUGINS-}" ]]; then
+  echo "No plugins to check against the whitelist (BUILDKITE_PLUGINS is unset)"
+  exit 0
+fi
+
 readarray -t PLUGINS_ALLOWED < "$WHITELIST_FILE_PATH"
 
 # We use base64, so we encode newlines and ensure you can't force a split

--- a/tests/check-valid.bats
+++ b/tests/check-valid.bats
@@ -2,6 +2,14 @@
 
 load "$BATS_PATH/load.bash"
 
+@test "Allows missing list of plugins (no plugins)" {
+  run \
+    "$PWD/check-plugins" "$PWD/tests/whitelist.txt"
+
+  assert_output --partial "BUILDKITE_PLUGINS is unset"
+  assert_success
+}
+
 @test "Allows valid plugins (single plugin, no config)" {
   run \
     env BUILDKITE_PLUGINS='[{"github.com/buildkite-plugins/docker-compose-buildkite-plugin#v1.6.0":null}]' \


### PR DESCRIPTION
When no plugins are requested, then `BUILDKITE_PLUGINS` is not set, causing an error with bash strict mode:

> /usr/local/src/buildkite-plugin-whitelister/check-plugins: line 39: BUILDKITE_PLUGINS: unbound variable