### PR TITLE
fix bats load path

### DIFF
--- a/tests/check-invalid.bats
+++ b/tests/check-invalid.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-load "$BATS_PATH/load.bash"
+load '/usr/local/lib/bats/load.bash'
 
 @test "Disallows bad plugins" {
   run \

--- a/tests/check-valid.bats
+++ b/tests/check-valid.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-load "$BATS_PATH/load.bash"
+load '/usr/local/lib/bats/load.bash'
 
 @test "Allows missing list of plugins (no plugins)" {
   run \

--- a/tests/usage.bats
+++ b/tests/usage.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-load "$BATS_PATH/load.bash"
+load '/usr/local/lib/bats/load.bash'
 
 @test "No allowed-plugins arg given" {
   run $PWD/check-plugins


### PR DESCRIPTION
Fixes #3 

`$BATS_PATH` is not set in the environment by default